### PR TITLE
qz.com font mixin updates

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -23,7 +23,7 @@
 
 @mixin font-maison-500-1 {
 	@include font-maison;
-	@include font-size-helper($size-font-01-mobile, $size-font-01, null);
+	@include font-size-helper(11px, 13px, null);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -31,7 +31,7 @@
 
 @mixin font-maison-500-2 {
 	@include font-maison;
-	@include font-size-helper($size-font-02-mobile, $size-font-02, null);
+	@include font-size-helper(14px, 16px, null);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -39,7 +39,7 @@
 
 @mixin font-maison-500-3 {
 	@include font-maison;
-	@include font-size-helper($size-font-03-mobile, $size-font-03, null);
+	@include font-size-helper(14px, 20px, null);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -55,7 +55,7 @@
 
 @mixin font-maison-500-5 {
 	@include font-maison;
-	@include font-size-helper($size-font-05-mobile, $size-font-05-tablet, $size-font-05);
+	@include font-size-helper(14px, 20px, 30px);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -71,7 +71,7 @@
 
 @mixin font-maison-extended-700-1 {
 	@include font-maison-extended;
-	@include font-size-helper($size-font-01-mobile, $size-font-01, null);
+	@include font-size-helper(11px, 13px, null);
 
 	font-weight: 700;
 	line-height: $font-line-height-maison-extra-bold;
@@ -79,7 +79,7 @@
 
 @mixin font-maison-extended-700-2 {
 	@include font-maison-extended;
-	@include font-size-helper($size-font-02-mobile, $size-font-02, null);
+	@include font-size-helper(14px, 16px, null);
 
 	font-weight: 700;
 	line-height: $font-line-height-maison-extra-bold;
@@ -87,7 +87,7 @@
 
 @mixin font-maison-800-1 {
 	@include font-maison;
-	@include font-size-helper($size-font-01-mobile, $size-font-01, null);
+	@include font-size-helper(11px, 13px, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -95,7 +95,7 @@
 
 @mixin font-maison-800-2 {
 	@include font-maison;
-	@include font-size-helper($size-font-02-mobile, $size-font-02, null);
+	@include font-size-helper(14px, 16px, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -103,7 +103,7 @@
 
 @mixin font-maison-800-3 {
 	@include font-maison;
-	@include font-size-helper($size-font-03-mobile, $size-font-03, null);
+	@include font-size-helper(14px, 20px, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -111,7 +111,7 @@
 
 @mixin font-maison-800-4 {
 	@include font-maison;
-	@include font-size-helper($size-font-04-mobile, $size-font-04, null);
+	@include font-size-helper(18px, 20px, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -127,7 +127,7 @@
 
 @mixin font-maison-800-6 {
 	@include font-maison;
-	@include font-size-helper($size-font-06-mobile, $size-font-06, null);
+	@include font-size-helper(24px, 40px, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -143,7 +143,7 @@
 
 @mixin font-maison-800-9 {
 	@include font-maison;
-	@include font-size-helper($size-font-09-mobile, $size-font-09-tablet, $size-font-09);
+	@include font-size-helper(26px, 50px, 70px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;

--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -111,7 +111,7 @@
 
 @mixin font-maison-800-4 {
 	@include font-maison;
-	@include font-size-helper(18px, 20px, null);
+	@include font-size-helper(16px, 20px, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;

--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -23,7 +23,7 @@
 
 @mixin font-maison-500-1 {
 	@include font-maison;
-	@include font-size-helper($size-font-01-mobile, $size-font-01, null, null);
+	@include font-size-helper($size-font-01-mobile, $size-font-01, null);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -31,7 +31,7 @@
 
 @mixin font-maison-500-2 {
 	@include font-maison;
-	@include font-size-helper($size-font-02-mobile, $size-font-02, null, null);
+	@include font-size-helper($size-font-02-mobile, $size-font-02, null);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -39,7 +39,7 @@
 
 @mixin font-maison-500-3 {
 	@include font-maison;
-	@include font-size-helper($size-font-03-mobile, $size-font-03, null, null);
+	@include font-size-helper($size-font-03-mobile, $size-font-03, null);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -47,7 +47,7 @@
 
 @mixin font-maison-500-4 {
 	@include font-maison;
-	@include font-size-helper($size-font-04-mobile, $size-font-04, null, null);
+	@include font-size-helper(16px, 20px, null);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -55,7 +55,7 @@
 
 @mixin font-maison-500-5 {
 	@include font-maison;
-	@include font-size-helper($size-font-05-mobile, $size-font-05-tablet, null, $size-font-05);
+	@include font-size-helper($size-font-05-mobile, $size-font-05-tablet, $size-font-05);
 
 	font-weight: 500;
 	line-height: $font-line-height-maison-medium;
@@ -63,7 +63,7 @@
 
 @mixin font-pt-serif-400-1 {
 	@include font-pt-serif;
-	@include font-size-helper($size-font-04-mobile, $size-font-04, null, null);
+	@include font-size-helper(16px, 20px, null);
 
 	font-weight: 400;
 	line-height: $font-line-height-pt-serif;
@@ -71,7 +71,7 @@
 
 @mixin font-maison-extended-700-1 {
 	@include font-maison-extended;
-	@include font-size-helper($size-font-01-mobile, $size-font-01, null, null);
+	@include font-size-helper($size-font-01-mobile, $size-font-01, null);
 
 	font-weight: 700;
 	line-height: $font-line-height-maison-extra-bold;
@@ -79,23 +79,7 @@
 
 @mixin font-maison-extended-700-2 {
 	@include font-maison-extended;
-	@include font-size-helper($size-font-02-mobile, $size-font-02, null, null);
-
-	font-weight: 700;
-	line-height: $font-line-height-maison-extra-bold;
-}
-
-@mixin font-maison-extended-700-3 {
-	@include font-maison-extended;
-	@include font-size-helper($size-font-03-mobile, $size-font-03, null, null);
-
-	font-weight: 700;
-	line-height: $font-line-height-maison-extra-bold;
-}
-
-@mixin font-maison-extended-700-4 {
-	@include font-maison-extended;
-	@include font-size-helper($size-font-04-mobile, $size-font-04, null, 30px);
+	@include font-size-helper($size-font-02-mobile, $size-font-02, null);
 
 	font-weight: 700;
 	line-height: $font-line-height-maison-extra-bold;
@@ -103,7 +87,7 @@
 
 @mixin font-maison-800-1 {
 	@include font-maison;
-	@include font-size-helper($size-font-01-mobile, $size-font-01, null, null);
+	@include font-size-helper($size-font-01-mobile, $size-font-01, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -111,7 +95,7 @@
 
 @mixin font-maison-800-2 {
 	@include font-maison;
-	@include font-size-helper($size-font-02-mobile, $size-font-02, null, null);
+	@include font-size-helper($size-font-02-mobile, $size-font-02, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -119,7 +103,7 @@
 
 @mixin font-maison-800-3 {
 	@include font-maison;
-	@include font-size-helper($size-font-03-mobile, $size-font-03, null, null);
+	@include font-size-helper($size-font-03-mobile, $size-font-03, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -127,7 +111,7 @@
 
 @mixin font-maison-800-4 {
 	@include font-maison;
-	@include font-size-helper($size-font-04-mobile, $size-font-04, null, null);
+	@include font-size-helper($size-font-04-mobile, $size-font-04, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -135,8 +119,7 @@
 
 @mixin font-maison-800-5 {
 	@include font-maison;
-	// TODO: this changed and the mobile size is larger than maison-800-6 so I'm not sure how it fits in;
-	@include font-size-helper(24px, 30px, null, null);
+	@include font-size-helper(20px, 32px, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -144,7 +127,7 @@
 
 @mixin font-maison-800-6 {
 	@include font-maison;
-	@include font-size-helper($size-font-06-mobile, $size-font-06, null, null);
+	@include font-size-helper($size-font-06-mobile, $size-font-06, null);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -152,15 +135,7 @@
 
 @mixin font-maison-800-7 {
 	@include font-maison;
-	@include font-size-helper($size-font-07-mobile, $size-font-07-tablet, $size-font-07, null);
-
-	font-weight: 800;
-	line-height: $font-line-height-maison-extra-bold;
-}
-
-@mixin font-maison-800-8 {
-	@include font-maison;
-	@include font-size-helper($size-font-08-mobile, $size-font-08, null, null);
+	@include font-size-helper(16px, 30px, 45px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -168,7 +143,7 @@
 
 @mixin font-maison-800-9 {
 	@include font-maison;
-	@include font-size-helper($size-font-09-mobile, $size-font-09-tablet, $size-font-09, null);
+	@include font-size-helper($size-font-09-mobile, $size-font-09-tablet, $size-font-09);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -176,15 +151,15 @@
 
 @mixin font-maison-800-10 {
 	@include font-maison;
-	@include font-size-helper($size-font-10-mobile, $size-font-10-tablet, null, $size-font-10);
+	@include font-size-helper(32px, 70px, 84px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
 }
 
-@mixin font-publico-800-2 {
+@mixin font-publico-800-1 {
 	@include font-publico-headline;
-	@include font-size-helper(30px, 40px, 60px, 70px);
+	@include font-size-helper(26px, 50px, 70px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -269,7 +244,7 @@ $font-graphik: 'Graphik', $font-graphik-fallback;
  * special editorial project, you should use the break points directly
  * in your component's CSS file.
  * */
-@mixin font-size-helper($mobile, $tablet-portrait: null, $tablet-landscape: null, $desktop: null) {
+@mixin font-size-helper($mobile, $tablet-portrait: null, $tablet-landscape: null) {
 	font-size: $mobile;
 
 	@if $tablet-portrait != null {
@@ -281,12 +256,6 @@ $font-graphik: 'Graphik', $font-graphik-fallback;
 	@if $tablet-landscape != null {
 		@include for-tablet-landscape-up {
 			font-size: $tablet-landscape;
-		}
-	}
-
-	@if $desktop != null {
-		@include for-desktop-up {
-			font-size: $desktop;
 		}
 	}
 }

--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -135,7 +135,15 @@
 
 @mixin font-maison-800-7 {
 	@include font-maison;
-	@include font-size-helper(16px, 30px, 45px);
+	@include font-size-helper(16px, 28px, 48px);
+
+	font-weight: 800;
+	line-height: $font-line-height-maison-extra-bold;
+}
+
+@mixin font-maison-800-8 {
+	@include font-maison;
+	@include font-size-helper(18px, 24px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -143,7 +151,7 @@
 
 @mixin font-maison-800-9 {
 	@include font-maison;
-	@include font-size-helper(26px, 50px, 70px);
+	@include font-size-helper(24px, 48px, 64px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -151,7 +159,7 @@
 
 @mixin font-maison-800-10 {
 	@include font-maison;
-	@include font-size-helper(32px, 70px, 84px);
+	@include font-size-helper(28px, 64px, 80px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;
@@ -159,7 +167,7 @@
 
 @mixin font-publico-800-1 {
 	@include font-publico-headline;
-	@include font-size-helper(26px, 50px, 70px);
+	@include font-size-helper(24px, 48px, 64px);
 
 	font-weight: 800;
 	line-height: $font-line-height-maison-extra-bold;

--- a/scss/tokens.scss
+++ b/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 20 Jul 2020 22:14:34 GMT
+// Generated on Thu, 23 Jul 2020 15:21:43 GMT
 
 $size-breakpoint-tablet-portrait: 768px;
 $size-breakpoint-tablet-landscape: 1024px;

--- a/swift/QuartzStyles/QuartzStyles.swift
+++ b/swift/QuartzStyles/QuartzStyles.swift
@@ -3,7 +3,7 @@
 // QuartzStyles.swift
 //
 // Do not edit directly
-// Generated on Mon, 20 Jul 2020 22:14:34 GMT
+// Generated on Thu, 23 Jul 2020 15:21:43 GMT
 //
 
 import UIKit

--- a/xml/colors.xml
+++ b/xml/colors.xml
@@ -2,7 +2,7 @@
 
 <!--
   Do not edit directly
-  Generated on Mon, 20 Jul 2020 22:14:34 GMT
+  Generated on Thu, 23 Jul 2020 15:21:43 GMT
 -->
 <resources>
   <color name="color_accent_blue">#ff168dd9</color>

--- a/xml/font_dimens.xml
+++ b/xml/font_dimens.xml
@@ -2,7 +2,7 @@
 
 <!--
   Do not edit directly
-  Generated on Mon, 20 Jul 2020 22:14:34 GMT
+  Generated on Thu, 23 Jul 2020 15:21:43 GMT
 -->
 <resources>
   <dimen name="size_font_10">95.00sp</dimen>


### PR DESCRIPTION
Daniel has done an audit of our font mixins and sent over some change requests, which can be found here https://docs.google.com/spreadsheets/d/1OOHEwFf8Q8-OSC7cOhoVbDkwZfT6S1jhrX2lKZa5c3U/edit#gid=0

A lot of pixel values have changed and a few mixins can be removed. Significantly, font mixins now only support three breakpoints, as we have consolidated tablet-landscape and desktop font sizes. This means all font sizes won't change about 1024px-wide viewports.

I've switched out the use of token variables for hardcoded pixel values in this file. The current setup makes it hard to know what values are being used where, and I'm not sure we want changes to these tokens to be reflected everywhere. If that's incorrect let me know.

During cooldown I plan to have a rethink of our font mixins, specifically how we name them. It's become clear that our current naming convention isn't flexible or clear enough in practice.