### PR TITLE
Apply uppercase and hyphenation to kicker-only mixin

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -75,6 +75,10 @@
 
 	font-weight: 700;
 	line-height: $font-line-height-maison-extra-bold;
+	text-transform: uppercase;
+	-webkit-hyphens: auto;
+	-ms-hyphens: auto;
+	hyphens: auto;
 }
 
 @mixin font-maison-extended-700-2 {

--- a/scss/tokens.scss
+++ b/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 31 Jul 2020 14:11:06 GMT
+// Generated on Mon, 03 Aug 2020 16:33:57 GMT
 
 $size-breakpoint-tablet-portrait: 768px;
 $size-breakpoint-tablet-landscape: 1024px;

--- a/swift/QuartzStyles/QuartzStyles.swift
+++ b/swift/QuartzStyles/QuartzStyles.swift
@@ -3,7 +3,7 @@
 // QuartzStyles.swift
 //
 // Do not edit directly
-// Generated on Fri, 31 Jul 2020 14:11:06 GMT
+// Generated on Mon, 03 Aug 2020 16:33:57 GMT
 //
 
 import UIKit


### PR DESCRIPTION
`font-maison-extended-700-1` should only ever be used for 'kicker' type treatments, i.e. we will always it to be uppercase and hyphenated when wrapping. Moving these rules here will allow us to remove the `kicker` mixin from qz-react.