### PR TITLE
Enforce Maison Neue Extended uppercase

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -87,6 +87,10 @@
 
 	font-weight: 700;
 	line-height: $font-line-height-maison-extra-bold;
+	text-transform: uppercase;
+	-webkit-hyphens: auto;
+	-ms-hyphens: auto;
+	hyphens: auto;
 }
 
 @mixin font-maison-800-1 {

--- a/scss/tokens.scss
+++ b/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 03 Aug 2020 16:33:57 GMT
+// Generated on Mon, 14 Sep 2020 19:28:56 GMT
 
 $size-breakpoint-tablet-portrait: 768px;
 $size-breakpoint-tablet-landscape: 1024px;

--- a/swift/QuartzStyles/QuartzStyles.swift
+++ b/swift/QuartzStyles/QuartzStyles.swift
@@ -3,7 +3,7 @@
 // QuartzStyles.swift
 //
 // Do not edit directly
-// Generated on Mon, 03 Aug 2020 16:33:57 GMT
+// Generated on Mon, 14 Sep 2020 19:28:56 GMT
 //
 
 import UIKit


### PR DESCRIPTION
Whenever we use Maison Neue Extended, it should be uppercased for a kicker-esque treatment. To enforce this informal rule, this PR adds `text-transform: uppercase` to the `font-maison-extended-700-2` mixin. The only other Maison Neue mixin, `font-maison-extended-700-1`, already has this rule.