### PR TITLE
Remove fonts-loaded

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -23,57 +23,57 @@
  */
 
 @mixin maison-500-1 {
-	@include maison;
 	@include font-size-helper(11px, 13px, null);
 
+	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-2 {
-	@include maison;
 	@include font-size-helper(14px, 16px, null);
 
+	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-3 {
-	@include maison;
 	@include font-size-helper(14px, 20px, null);
 
+	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-4 {
-	@include maison;
 	@include font-size-helper(16px, 20px, null);
 
+	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-5 {
-	@include maison;
 	@include font-size-helper(14px, 20px, 30px);
 
+	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin pt-serif-400-1 {
-	@include pt-serif;
 	@include font-size-helper(16px, 20px, null);
 
+	font-family: $pt-serif;
 	font-weight: 400;
 	line-height: tokens.$font-line-height-pt-serif;
 }
 
 @mixin maison-extended-700-1 {
-	@include maison-extended;
 	@include font-size-helper(11px, 13px, null);
 
+	font-family: $maison-extended;
 	font-weight: 700;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 	text-transform: uppercase;
@@ -83,9 +83,9 @@
 }
 
 @mixin maison-extended-700-2 {
-	@include maison-extended;
 	@include font-size-helper(14px, 16px, null);
 
+	font-family: $maison-extended;
 	font-weight: 700;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 	text-transform: uppercase;
@@ -95,164 +95,107 @@
 }
 
 @mixin maison-800-1 {
-	@include maison;
 	@include font-size-helper(11px, 13px, null);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-2 {
-	@include maison;
 	@include font-size-helper(14px, 16px, null);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-3 {
-	@include maison;
 	@include font-size-helper(14px, 20px, null);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-4 {
-	@include maison;
 	@include font-size-helper(16px, 20px, null);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-5 {
-	@include maison;
 	@include font-size-helper(20px, 32px, null);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-6 {
-	@include maison;
 	@include font-size-helper(24px, 40px, null);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-7 {
-	@include maison;
 	@include font-size-helper(16px, 28px, 48px);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-8 {
-	@include maison;
 	@include font-size-helper(18px, 24px);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-9 {
-	@include maison;
 	@include font-size-helper(24px, 48px, 64px);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-10 {
-	@include maison;
 	@include font-size-helper(28px, 64px, 80px);
 
+	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin publico-800-1 {
-	@include publico-headline;
 	@include font-size-helper(24px, 48px, 64px);
 
+	font-family: $publico-headline;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
-/**
- * Helper mixins
- *
- * Avoid using the following mixins outside this file whenever
- * possible.
- */
-
-@mixin graphik {
-	font-family: $graphik-fallback;
-
-	:global(.fonts-loaded) & {
-		font-family: $graphik;
-	}
-}
-
-@mixin maison {
-	font-family: $maison-fallback;
-
-	:global(.fonts-loaded) & {
-		font-family: $maison;
-	}
-}
-
-@mixin maison-extended {
-	font-family: $maison-fallback;
-
-	:global(.fonts-loaded) & {
-		font-family: $maison-extended;
-	}
-}
-
-@mixin pt-serif {
-	font-family: $pt-serif-fallback;
-
-	:global(.fonts-loaded) & {
-		font-family: $pt-serif;
-	}
-}
-
-@mixin publico-headline {
-	font-family: $publico-headline-fallback;
-
-	:global(.fonts-loaded) & {
-		font-family: $publico-headline;
-	}
-}
-
 /*
-	STOP HERE!
-
- 	Do not reference the following variables or mixins outside this file!
-*/
-
-/**
- * Do not use these variables directly! Use a mixin to ensure
- * non-system fonts are only applied once loaded in order to
- * prevent FOIT.
+ * STOP HERE!
+ *
+ * Do not reference the following variables outside this file!
+ *
+ * Use a mixin to ensure non-system fonts are loaded correctly.
  */
 $font-default-sans-fallback: -apple-system, 'Helvetica Neue', Helvetica, 'Hiragino Sans', sans-serif;
 $font-default-serif-fallback: Georgia, 'Hiragino Sans', serif;
 
-$maison-fallback: $font-default-sans-fallback;
-$graphik-fallback: $font-default-sans-fallback;
-$publico-headline-fallback: $font-default-serif-fallback;
-$pt-serif-fallback: $font-default-serif-fallback;
-
-$maison: 'MaisonNeue', $maison-fallback;
-$maison-extended: 'MaisonNeueExtended', $maison-fallback;
-$publico-headline: 'Publico Headline', $publico-headline-fallback;
-$pt-serif: 'PTSerif', $pt-serif-fallback;
-$graphik: 'Graphik', $graphik-fallback;
+$maison: 'MaisonNeue', $font-default-sans-fallback;
+$maison-extended: 'MaisonNeueExtended', $font-default-sans-fallback;
+$publico-headline: 'Publico Headline', $font-default-serif-fallback;
+$pt-serif: 'PTSerif', $font-default-serif-fallback;
 
 /**
  * Do not use this mixin directly! This mixin is only to be used the

--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -23,57 +23,57 @@
  */
 
 @mixin maison-500-1 {
+	@include maison;
 	@include font-size-helper(11px, 13px, null);
 
-	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-2 {
+	@include maison;
 	@include font-size-helper(14px, 16px, null);
 
-	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-3 {
+	@include maison;
 	@include font-size-helper(14px, 20px, null);
 
-	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-4 {
+	@include maison;
 	@include font-size-helper(16px, 20px, null);
 
-	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin maison-500-5 {
+	@include maison;
 	@include font-size-helper(14px, 20px, 30px);
 
-	font-family: $maison;
 	font-weight: 500;
 	line-height: tokens.$font-line-height-maison-medium;
 }
 
 @mixin pt-serif-400-1 {
+	@include pt-serif;
 	@include font-size-helper(16px, 20px, null);
 
-	font-family: $pt-serif;
 	font-weight: 400;
 	line-height: tokens.$font-line-height-pt-serif;
 }
 
 @mixin maison-extended-700-1 {
+	@include maison-extended;
 	@include font-size-helper(11px, 13px, null);
 
-	font-family: $maison-extended;
 	font-weight: 700;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 	text-transform: uppercase;
@@ -83,9 +83,9 @@
 }
 
 @mixin maison-extended-700-2 {
+	@include maison-extended;
 	@include font-size-helper(14px, 16px, null);
 
-	font-family: $maison-extended;
 	font-weight: 700;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 	text-transform: uppercase;
@@ -95,100 +95,124 @@
 }
 
 @mixin maison-800-1 {
+	@include maison;
 	@include font-size-helper(11px, 13px, null);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-2 {
+	@include maison;
 	@include font-size-helper(14px, 16px, null);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-3 {
+	@include maison;
 	@include font-size-helper(14px, 20px, null);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-4 {
+	@include maison;
 	@include font-size-helper(16px, 20px, null);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-5 {
+	@include maison;
 	@include font-size-helper(20px, 32px, null);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-6 {
+	@include maison;
 	@include font-size-helper(24px, 40px, null);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-7 {
+	@include maison;
 	@include font-size-helper(16px, 28px, 48px);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-8 {
+	@include maison;
 	@include font-size-helper(18px, 24px);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-9 {
+	@include maison;
 	@include font-size-helper(24px, 48px, 64px);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin maison-800-10 {
+	@include maison;
 	@include font-size-helper(28px, 64px, 80px);
 
-	font-family: $maison;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
 }
 
 @mixin publico-800-1 {
+	@include publico-headline;
 	@include font-size-helper(24px, 48px, 64px);
 
-	font-family: $publico-headline;
 	font-weight: 800;
 	line-height: tokens.$font-line-height-maison-extra-bold;
+}
+
+/**
+ * Helper mixins
+ *
+ * Avoid using the following mixins outside this file whenever
+ * possible.
+ */
+
+@mixin maison {
+	font-family: $maison;
+}
+
+@mixin maison-extended {
+	font-family: $maison-extended;
+}
+
+@mixin pt-serif {
+	font-family: $pt-serif;
+}
+
+@mixin publico-headline {
+	font-family: $publico-headline;
 }
 
 /*
  * STOP HERE!
  *
- * Do not reference the following variables outside this file!
+ * Do not reference the following variables or mixins outside this file!
  *
  * Use a mixin to ensure non-system fonts are loaded correctly.
- */
+*/
+
 $font-default-sans-fallback: -apple-system, 'Helvetica Neue', Helvetica, 'Hiragino Sans', sans-serif;
 $font-default-serif-fallback: Georgia, 'Hiragino Sans', serif;
 

--- a/scss/tokens.scss
+++ b/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 14 Oct 2020 13:28:47 GMT
+// Generated on Mon, 02 Nov 2020 18:02:01 GMT
 
 $size-breakpoint-tablet-portrait: 768px;
 $size-breakpoint-tablet-landscape: 1024px;

--- a/swift/QuartzStyles/QuartzStyles.swift
+++ b/swift/QuartzStyles/QuartzStyles.swift
@@ -3,7 +3,7 @@
 // QuartzStyles.swift
 //
 // Do not edit directly
-// Generated on Wed, 14 Oct 2020 13:28:47 GMT
+// Generated on Mon, 02 Nov 2020 18:02:01 GMT
 //
 
 import UIKit


### PR DESCRIPTION
There is now broad support for `font-display: swap`, which means we no longer need to simulate this approach by adding a class once fonts are loaded.

Remove Graphik completely.