### PR TITLE
Add alt dark background color

### DIFF
--- a/dictionaries/colors.json
+++ b/dictionaries/colors.json
@@ -9,6 +9,9 @@
     "dark-blue": {
       "value": "#171a23"
     },
+    "mid-dark-blue": {
+      "value": "#232634"
+    },
     "light-blue": {
       "value": "#bcdef3"
     },

--- a/scss/tokens.scss
+++ b/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 02 Nov 2020 18:02:01 GMT
+// Generated on Fri, 20 Nov 2020 16:38:47 GMT
 
 $size-breakpoint-tablet-portrait: 768px;
 $size-breakpoint-tablet-landscape: 1024px;
@@ -16,6 +16,7 @@ $size-gutter-desktop-work: 40px;
 $color-accent-blue: #168dd9;
 $color-accent-blue-dark: #76cbff;
 $color-dark-blue: #171a23;
+$color-mid-dark-blue: #232634;
 $color-light-blue: #bcdef3;
 $color-black: #000000;
 $color-gold: #f1a33f;

--- a/swift/QuartzStyles/QuartzStyles.swift
+++ b/swift/QuartzStyles/QuartzStyles.swift
@@ -3,7 +3,7 @@
 // QuartzStyles.swift
 //
 // Do not edit directly
-// Generated on Mon, 02 Nov 2020 18:02:01 GMT
+// Generated on Fri, 20 Nov 2020 16:38:47 GMT
 //
 
 import UIKit
@@ -22,6 +22,7 @@ public enum QuartzStyles {
     public static let colorLightBlue = UIColor(red: 0.737, green: 0.871, blue: 0.953, alpha:1)
     public static let colorLightGray = UIColor(red: 0.886, green: 0.886, blue: 0.886, alpha:1)
     public static let colorLightTeal = UIColor(red: 0.761, green: 0.898, blue: 0.933, alpha:1)
+    public static let colorMidDarkBlue = UIColor(red: 0.137, green: 0.149, blue: 0.204, alpha:1)
     public static let colorOffWhite = UIColor(red: 0.976, green: 0.976, blue: 0.976, alpha:1)
     public static let colorPink = UIColor(red: 1.000, green: 0.608, blue: 0.871, alpha:1)
     public static let colorRed = UIColor(red: 0.761, green: 0.322, blue: 0.314, alpha:1)


### PR DESCRIPTION
Add a color value to be used as an alternate background color for dark themes. Slightly lighter than `dark-blue`.