### PR TITLE
QZ-766 Navigation color schemes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Switch to Xcode 11
-        run: ls /Applications; sudo xcode-select -s /Applications/Xcode_11.5.app
+        run: ls /Applications; sudo xcode-select -s /Applications/Xcode_11.7.app
 
       - run: swift package generate-xcodeproj
 

--- a/scss/color-scheme.scss
+++ b/scss/color-scheme.scss
@@ -6,11 +6,14 @@
 	approximation of the default theme (Quartz Light).
 */
 $accent: var(--color-accent, tokens.$color-accent-blue);
+$accent-navigation: var(--color-accent-navigation, tokens.$color-accent-blue);
 $background-1: var(--color-background-1, tokens.$color-off-white);
 $background-1-transparent: var(--color-background-1-transparent, rgba(255, 255, 255, 0.000001));
 $background-2: var(--color-background-2, tokens.$color-white);
 $background-3: var(--color-background-3, rgba(0, 0, 0, 0.15));
 $background-4: var(--color-background-4, tokens.$color-white);
+$background-navigation: var(--color-background-navigation, tokens.$color-off-white);
+$background-navigation-faint: var(--color-background-navigation-faint, tokens.$color-white);
 $background-modal: var(--color-background-modal, rgba(0, 0, 0, 0.98));
 $border-decorative: var(--color-border-decorative, rgba(0, 0, 0, 0.15));
 $border-interactive: var(--color-border-interactive, rgba(0, 0, 0, 0.3));
@@ -18,3 +21,5 @@ $highlight: var(--color-highlight, rgba(22, 141, 217, 0.2));
 $typography: var(--color-typography, tokens.$color-black);
 $typography-faint: var(--color-typography-faint, rgba(0, 0, 0, 0.7));
 $typography-inverted: var(--color-typography-inverted, tokens.$color-white);
+$typography-navigation: var(--color-typography-navigation, tokens.$color-black);
+$typography-navigation-faint: var(--color-typography-navigation-faint, rgba(0, 0, 0, 0.7));

--- a/scss/tokens.scss
+++ b/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Mar 2022 19:06:38 GMT
+// Generated on Fri, 15 Apr 2022 17:39:36 GMT
 
 $size-breakpoint-tablet-portrait: 768px;
 $size-breakpoint-tablet-landscape: 1024px;

--- a/swift/QuartzStyles/QuartzStyles.swift
+++ b/swift/QuartzStyles/QuartzStyles.swift
@@ -3,7 +3,7 @@
 // QuartzStyles.swift
 //
 // Do not edit directly
-// Generated on Wed, 23 Mar 2022 19:06:38 GMT
+// Generated on Fri, 15 Apr 2022 17:39:36 GMT
 //
 
 import UIKit


### PR DESCRIPTION
Allow separate color schemes for navigation elements (e.g. Site Nav.)

This is to allow the SiteNav and content background to have different color scheme, like this page:
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/97528742/163422781-e932492b-3e55-4216-bd08-b9f58dde1c03.png">

This change is part of the design update for the email webview page ([ticket](https://linear.app/qz/issue/QZ-766/update-the-email-webview))